### PR TITLE
optimized unlinking of junctioned dirs on windows

### DIFF
--- a/collective/recipe/omelette/utils.py
+++ b/collective/recipe/omelette/utils.py
@@ -16,15 +16,19 @@ if WIN32:
     
     def unlink(path):
         if not ntfsutils.junction.isjunction(path):
-            return
+            return False
         ntfsutils.junction.unlink(path)
+        return True
     
     def rmtree(location, nonlinks=True):
         # Explicitly unlink all junction'd links
-        for root, dirs, files in os.walk(location, topdown=False):
-            for dir in dirs:
-                path = os.path.join(root, dir)
-                unlink(path)
+        names = os.listdir(location)
+        for dir in names:
+            path = os.path.join(location, dir)
+            if unlink(path):
+                continue
+            if os.path.isdir(path):
+                rmtree(path)
         # Then get rid of everything else
         if nonlinks:
             shutil.rmtree(location)


### PR DESCRIPTION
Hi,
on my system it took 5 minutes to remove the entire dir. structure of buildout.coredev. With this patch it took 10 seconds. I tested this patch with latest plone buildout.coredev.

Regards
Roman
