### PR TITLE
Fix handling checkouts of native namespace packages.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,13 @@
 2.0.0 (unreleased)
 ==================
 
+Breaking changes:
+
+- Remove ``products`` recipe option and special handling of ``Products`` namespace.
+  Zope 4 and higher no longer have the concept of a products directory.
+  You can still use ``packages = path/to/products_dir Products`` if you need something similar.
+  [maurits]
+
 - Require at least Python 3.9.
   [maurits]
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,11 @@ Breaking changes:
 - Require at least Python 3.9.
   [maurits]
 
+Bug fixes:
+
+- Fix handling checkouts of native namespace packages.
+  [maurits]
+
 
 1.1.1 (2025-02-12)
 ==================

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,11 @@
 
 Breaking changes:
 
+- No longer generate ``__init__.py`` files with namespace stanza in ``parts/omelette``.
+  I think this was originally done to be able to go to ``parts/omelette``, start a standard Python, and be able to import everything.
+  With current Python versions the ``__init__.py`` files are not needed for a directory to be importable.
+  [maurits]
+
 - Remove ``products`` recipe option and special handling of ``Products`` namespace.
   Zope 4 and higher no longer have the concept of a products directory.
   You can still use ``packages = path/to/products_dir Products`` if you need something similar.

--- a/README.rst
+++ b/README.rst
@@ -76,14 +76,9 @@ ignores
 packages
     List of Python packages whose contents should be included in the omelette.  Each line should be in the format
     [packages_location] [target_directory], where packages_location is the real location of the packages, and
-    target_directory is the (relative) location where the package should be inserted into the omelette (defaults
-    to Products/).
-    Example: ``packages = ${buildout:directory}/lib/python3.13/site-packages ./``
-
-products
-    (optional) List of old Zope 2-style products directories whose contents should be included in the omelette,
-    one per line.  (For backwards-compatibility -- equivalent to using packages with Products as the target
-    directory.)
+    target_directory is the optional (relative) location where the package should be inserted into the omelette (defaults
+    to ``./``, so directly in the omelette part).
+    Example: ``packages = ${buildout:directory}/lib/python3.13/site-packages``
 
 
 Using omelette with zipped eggs

--- a/collective/recipe/omelette/__init__.py
+++ b/collective/recipe/omelette/__init__.py
@@ -53,7 +53,7 @@ def makedirs(target, is_namespace=False):
             init_filename = os.path.join(current, "__init__.py")
             if not os.path.exists(init_filename):
                 init_file = open(init_filename, "w")
-                if is_namespace or part == "Products":
+                if is_namespace:
                     init_file.write(NAMESPACE_STANZA)
                 else:
                     init_file.write("# mushroom")
@@ -82,10 +82,7 @@ class Recipe:
             develop_eggs = [dev_egg[:-9] for dev_egg in develop_eggs]
         ignores = options.get("ignores", "").split()
         self.ignored_eggs = develop_eggs + ignores
-
-        products = options.get("products", "").split()
-        self.packages = [(p, "Products") for p in products]
-        self.packages += [
+        self.packages = [
             line.split()
             for line in options.get("packages", "").splitlines()
             if line.strip()
@@ -208,7 +205,7 @@ class Recipe:
 
         for package in self.packages:
             if len(package) == 1:
-                link_name = "Products/"
+                link_name = "./"
                 package_dir = package[0]
             elif len(package) == 2:
                 link_name = package[1]

--- a/collective/recipe/omelette/__init__.py
+++ b/collective/recipe/omelette/__init__.py
@@ -28,18 +28,12 @@ import zc.recipe.egg
 
 
 WIN32 = sys.platform[:3].lower() == "win"
-NAMESPACE_STANZA = """# See http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    from pkgutil import extend_path
-    __path__ = extend_path(__path__, __name__)
-"""
 
 
-def makedirs(target, is_namespace=False):
-    """Similar to os.makedirs, but adds __init__.py files as it goes.  Returns a boolean
-    indicating success.
+def makedirs(target):
+    """Similar to os.makedirs, but stops when it encounters a link.
+
+    Returns a boolean indicating success or failure.
     """
     drive, path = os.path.splitdrive(target)
     parts = path.split(os.path.sep)
@@ -50,14 +44,6 @@ def makedirs(target, is_namespace=False):
             return False
         if not os.path.exists(current):
             os.mkdir(current)
-            init_filename = os.path.join(current, "__init__.py")
-            if not os.path.exists(init_filename):
-                init_file = open(init_filename, "w")
-                if is_namespace:
-                    init_file.write(NAMESPACE_STANZA)
-                else:
-                    init_file.write("# mushroom")
-                init_file.close()
     return True
 
 
@@ -107,7 +93,7 @@ class Recipe:
                     ns_parts = ns_base + (k,)
                     link_dir = os.path.join(location, *ns_parts)
                     if not os.path.exists(link_dir):
-                        if not makedirs(link_dir, is_namespace=True):
+                        if not makedirs(link_dir):
                             self.logger.warning(
                                 "Warning: (While processing egg %s) Could not create namespace directory (%s).  Skipping.",
                                 project_name,

--- a/collective/recipe/omelette/__init__.py
+++ b/collective/recipe/omelette/__init__.py
@@ -85,6 +85,11 @@ class Recipe:
                 ns = namespaces
                 for part in line.split("."):
                     ns = ns.setdefault(part, {})
+            if "." in project_name and not namespaces:
+                ns = namespaces
+                for part in project_name.split(".")[:-1]:
+                    ns = ns.setdefault(part, {})
+
             top_level = sorted(list(dist._get_metadata("top_level.txt")))
             # native_libs = list(dist._get_metadata('native_libs.txt'))
 
@@ -100,6 +105,11 @@ class Recipe:
                                 link_dir,
                             )
                             continue
+                    if islink(link_dir):
+                        # For example, if you have packages one.two and one.three,
+                        # here you may already have a link to
+                        # .../lib/python3.12/site-packages/one/
+                        return
                     if len(v) > 0:
                         create_namespaces(v, ns_parts)
                     egg_ns_dir = os.path.join(dist.location, *ns_parts)

--- a/collective/recipe/omelette/tests/omelette.txt
+++ b/collective/recipe/omelette/tests/omelette.txt
@@ -12,8 +12,9 @@ Install a fancy omelette with an egg, some packages, and a product::
     ... [omelette]
     ... recipe = collective.recipe.omelette
     ... eggs = egg.with.name.different.from.contents
-    ... packages = %(test_dir)s/package .
-    ... products = %(test_dir)s/Products
+    ... packages =
+    ...     %(test_dir)s/Products Products
+    ...     %(test_dir)s/package .
     ... """ % globals())
     >>> run(buildout + ' -v')
     Installing...
@@ -78,8 +79,9 @@ stuff accidentally::
     ... [frittata]
     ... recipe = collective.recipe.omelette
     ... eggs = egg.with.name.different.from.contents
-    ... packages = %(test_dir)s/package .
-    ... products = %(test_dir)s/Products
+    ... packages =
+    ...     %(test_dir)s/Products Products
+    ...     %(test_dir)s/package .
     ... """ % globals())
     >>> 'frittata: Warning:' in system(buildout + ' -q')
     True

--- a/collective/recipe/omelette/tests/omelette.txt
+++ b/collective/recipe/omelette/tests/omelette.txt
@@ -41,7 +41,6 @@ Now we have everything linked together in one place, pointing at the real locati
     >>> ls('parts/omelette/Products')
     d  Product1
     d  Product2
-    -  __init__.py
     >>> ls('parts/omelette/Products/Product1')
     -  __init__.py
     -  in_Product1.txt
@@ -58,7 +57,6 @@ Add a new product and re-run buildout to make sure it updates::
     d  Product1
     d  Product2
     d  Product3
-    -  __init__.py
 
 Make sure we didn't clobber stuff that was linked from outside the omelette directory when we
 reinstalled (we needed to take extra care that this didn't happen when using junction on Windows!)::


### PR DESCRIPTION
This fixes issue #14.

* Fix handling checkouts of native namespace packages.  Sorry, no extra tests, but it works. :-)
* Remove ``products`` recipe option and special handling of ``Products`` namespace.
* No longer generate ``__init__.py`` files with namespace stanza in ``parts/omelette``.